### PR TITLE
fix(webtransport): buffer track objects that arrive before their SUBSCRIBE_OK binds an alias

### DIFF
--- a/packages/webtransport/src/adapter.test.ts
+++ b/packages/webtransport/src/adapter.test.ts
@@ -3802,6 +3802,235 @@ describe('MoqtConnection draft-14', () => {
   });
 });
 
+// ─── Pending-alias buffer rework (review response) ───────────────────
+//
+// Follow-up to the buffering fix above: the buffer must never claim an alias
+// still guarded by another (torn-down) subscription's terminal tombstone,
+// must fail closed (not silently discard while claiming the object) once any
+// limit is hit, must clear on every settlement/cancellation path via one
+// centralized helper, and must defer replay past the point where the caller
+// could have swapped its "mutable, read live" onObject/onSubgroupClosed.
+
+describe('pending-alias buffer rework (review response)', () => {
+  const enc = (s: string) => new TextEncoder().encode(s);
+
+  function findRequestId(mock: ReturnType<typeof createMockTransport>, type: string): bigint {
+    const codec = createControlCodec(16);
+    for (let i = mock.controlWritten.length - 1; i >= 0; i--) {
+      const { message } = codec.decode(mock.controlWritten[i]!, 0);
+      if (message.type === type) return (message as { requestId: bigint }).requestId;
+    }
+    throw new Error(`no ${type} found on the control stream`);
+  }
+
+  function pushSubscribeOk(mock: ReturnType<typeof createMockTransport>, requestId: bigint, alias: bigint): void {
+    mock.pushControlBytes(createControlCodec(16).encode({
+      type: 'SUBSCRIBE_OK', requestId, trackAlias: varint(alias),
+      parameters: new Map(), trackExtensions: [],
+    } as ControlMessage));
+  }
+
+  function pushObjectStream(mock: ReturnType<typeof createMockTransport>, alias: bigint, payload: Uint8Array): void {
+    const stream = mock.addIncomingStream();
+    stream.push(concat(
+      encodeSubgroupHeader(makeSubgroupHeader({ trackAlias: varint(alias) })),
+      encodeSubgroupObject(makeSubgroupObject({ objectId: varint(0), payload }), false, varint(0), true),
+    ));
+  }
+
+  it('the buffer refuses an alias still guarded by another subscription\'s terminal tombstone', async () => {
+    const mock = createMockTransport();
+    const adapter = await connectAdapter(mock);
+
+    // Establish and tear down track A on alias 42n — unsubscribe() arms a
+    // terminal tombstone synchronously (see TrackSubscription.unsubscribe).
+    // Every CURRENT caller of bufferPendingAlias (subgroup-stream and datagram
+    // handling) already pre-filters a tombstoned alias before ever reaching
+    // it — early-discarding the whole stream/datagram at the protocol layer
+    // (§10.11), so this can't be observed end-to-end through a live stream.
+    // The guarantee this test verifies is a property of the buffer itself:
+    // it must never claim a tombstoned alias regardless of what any caller
+    // (present or future) already filters upstream.
+    const subAP = adapter.subscribeTrack([enc('live')], enc('a'), { onObject: () => undefined });
+    await deepFlush();
+    pushSubscribeOk(mock, findRequestId(mock, 'SUBSCRIBE'), 42n);
+    const subA = await subAP;
+    await subA.unsubscribe();
+
+    // A second, unrelated subscription is pending throughout — the buffer's
+    // gate on "is anything pending at all" alone would happily buffer for it.
+    const subBP = adapter.subscribeTrack([enc('live')], enc('b'), { onObject: () => undefined });
+    await deepFlush();
+
+    type Internals = {
+      bufferPendingAlias(alias: bigint, obj: unknown, closeHeader: unknown): boolean;
+      terminatedAliases: Map<bigint, unknown>;
+      pendingAliasTimers: Map<bigint, unknown>;
+    };
+    const internals = adapter as unknown as Internals;
+    expect(internals.terminatedAliases.has(42n)).toBe(true); // tombstone is live
+
+    const straggler = {
+      kind: 'data', trackAlias: 42n, groupId: 0n, subgroupId: 0n, objectId: 0n,
+      publisherPriority: 128, payload: new Uint8Array([0xAB]),
+    };
+    expect(internals.bufferPendingAlias(42n, straggler, undefined)).toBe(false);
+    expect(internals.pendingAliasTimers.has(42n)).toBe(false); // no bucket ever created for it
+    void subBP; // deliberately left pending — never resolved/rejected in this test
+  });
+
+  it('replay is deferred past resolve() so a caller can swap onObject before buffered data arrives', async () => {
+    const mock = createMockTransport();
+    const adapter = await connectAdapter(mock);
+    const initialOnObject = vi.fn();
+
+    const subP = adapter.subscribeTrack([enc('live')], enc('vid'), { onObject: initialOnObject });
+    await deepFlush();
+    const reqId = findRequestId(mock, 'SUBSCRIBE');
+
+    pushObjectStream(mock, 7n, new Uint8Array([0x01]));
+    await deepFlush();
+
+    pushSubscribeOk(mock, reqId, 7n);
+    // Mirrors the documented "mutable, read live" contract: swap the handler
+    // in the very continuation that observes the resolved subscription.
+    const sub = await subP;
+    const realOnObject = vi.fn();
+    sub.onObject = realOnObject;
+    await deepFlush();
+
+    expect(initialOnObject).not.toHaveBeenCalled();
+    expect(realOnObject).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed on the per-alias object cap instead of silently claiming the overflow object', async () => {
+    const mock = createMockTransport();
+    const adapter = await connectAdapter(mock);
+    const unrouted: unknown[] = [];
+    adapter.onObject = (_sid, obj) => unrouted.push(obj);
+
+    const subP = adapter.subscribeTrack([enc('live')], enc('vid'), { onObject: () => undefined });
+    await deepFlush();
+
+    for (let i = 0; i < 257; i++) pushObjectStream(mock, 5n, new Uint8Array([i]));
+    await deepFlush();
+
+    expect(unrouted).toHaveLength(1); // only the 257th (over the 256 cap) fell through
+
+    pushSubscribeOk(mock, findRequestId(mock, 'SUBSCRIBE'), 5n);
+    const sub = await subP;
+    const delivered: number[] = [];
+    sub.onObject = (obj) => { if (obj.kind === 'data') delivered.push(obj.payload[0]!); };
+    await deepFlush();
+    expect(delivered).toEqual(Array.from({ length: 256 }, (_, i) => i)); // the first 256, in order
+  });
+
+  it('fails closed on the global distinct-alias cap and the global byte cap', async () => {
+    const mock = createMockTransport();
+    const adapter = await connectAdapter(mock);
+    const subP = adapter.subscribeTrack([enc('live')], enc('vid'), { onObject: () => undefined });
+    await deepFlush();
+
+    type Internals = {
+      bufferPendingAlias(alias: bigint, obj: unknown, closeHeader: unknown): boolean;
+      pendingAliasTimers: Map<bigint, unknown>;
+      pendingAliasTotalBytes: number;
+    };
+    const internals = adapter as unknown as Internals;
+    const dataObject = (alias: bigint, bytes: number) => ({
+      kind: 'data', trackAlias: alias, groupId: 0n, subgroupId: 0n, objectId: 0n,
+      publisherPriority: 128, payload: new Uint8Array(bytes),
+    });
+
+    // MAX_PENDING_ALIASES (64): the 65th distinct alias is refused outright.
+    for (let alias = 1n; alias <= 64n; alias++) {
+      expect(internals.bufferPendingAlias(alias, dataObject(alias, 1), undefined)).toBe(true);
+    }
+    expect(internals.bufferPendingAlias(65n, dataObject(65n, 1), undefined)).toBe(false);
+    expect(internals.pendingAliasTimers.size).toBe(64); // the refused 65th never got a bucket
+
+    // MAX_PENDING_TOTAL_BYTES (8 MiB): reuse one already-buffered alias so we're
+    // only exercising the GLOBAL byte cap, not the per-alias/per-count ones.
+    const totalBefore = internals.pendingAliasTotalBytes;
+    const remaining = 8 * 1024 * 1024 - totalBefore;
+    expect(internals.bufferPendingAlias(1n, dataObject(1n, remaining), undefined)).toBe(true);
+    expect(internals.bufferPendingAlias(1n, dataObject(1n, 1), undefined)).toBe(false); // one byte over → refused
+
+    void subP; // deliberately left pending — never resolved/rejected in this test
+  });
+
+  it('a buffered alias with no claiming SUBSCRIBE_OK expires via TTL and is not later replayed', async () => {
+    try {
+      const mock = createMockTransport();
+      const adapter = await connectAdapter(mock);
+      vi.useFakeTimers(); // enabled AFTER connect — connectAdapter's own flush() relies on real timers
+      const unrouted: unknown[] = [];
+      adapter.onObject = (_sid, obj) => unrouted.push(obj);
+
+      const subP = adapter.subscribeTrack([enc('live')], enc('vid'), { onObject: () => undefined });
+      await vi.advanceTimersByTimeAsync(0);
+
+      pushObjectStream(mock, 11n, new Uint8Array([0x9]));
+      await vi.advanceTimersByTimeAsync(0);
+
+      type Internals = { pendingAliasTimers: Map<bigint, unknown> };
+      expect((adapter as unknown as Internals).pendingAliasTimers.has(11n)).toBe(true);
+
+      // joiningFetchTimeoutMs default (10s) — the same TTL expireParkedJoin uses
+      // for the analogous Joining-Fetch parking structure.
+      await vi.advanceTimersByTimeAsync(10_001);
+      expect((adapter as unknown as Internals).pendingAliasTimers.has(11n)).toBe(false);
+
+      // A SUBSCRIBE_OK arriving AFTER expiry binds cleanly but replays nothing.
+      pushSubscribeOk(mock, findRequestId(mock, 'SUBSCRIBE'), 11n);
+      const sub = await subP;
+      expect(sub.trackAlias).toBe(11n);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(unrouted).toHaveLength(0); // the stale object was dropped at expiry, not replayed late
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('centralizes cleanup on REQUEST_ERROR: a rejected subscription cannot leak its buffered alias to a later, unrelated one', async () => {
+    const mock = createMockTransport();
+    const adapter = await connectAdapter(mock);
+    const onObjectLater = vi.fn();
+
+    const subAP = adapter.subscribeTrack([enc('live')], enc('a'), { onObject: () => undefined });
+    subAP.catch(() => undefined); // attach a handler now — it rejects mid-test, before the `.rejects` assertion below
+    await deepFlush();
+    const reqIdA = findRequestId(mock, 'SUBSCRIBE');
+
+    // An object races ahead for the alias the relay is ABOUT to (but never
+    // does) assign to A.
+    pushObjectStream(mock, 99n, new Uint8Array([0x7]));
+    await deepFlush();
+
+    type Internals = { pendingAliasTimers: Map<bigint, unknown> };
+    expect((adapter as unknown as Internals).pendingAliasTimers.has(99n)).toBe(true);
+
+    mock.pushControlBytes(createControlCodec(16).encode({
+      type: 'REQUEST_ERROR', requestId: reqIdA, errorCode: varint(0x0n),
+      retryInterval: varint(0n), errorReason: 'rejected', requestKind: 'SUBSCRIBE',
+    } as ControlMessage));
+    await deepFlush();
+    await expect(subAP).rejects.toThrow();
+
+    // The buffer (and its TTL timer) is gone — nothing left pending at all.
+    expect((adapter as unknown as Internals).pendingAliasTimers.has(99n)).toBe(false);
+
+    // A brand new, unrelated subscription later reuses alias 99n legitimately.
+    const subBP = adapter.subscribeTrack([enc('live')], enc('b'), { onObject: onObjectLater });
+    await deepFlush();
+    pushSubscribeOk(mock, findRequestId(mock, 'SUBSCRIBE'), 99n);
+    await deepFlush();
+    await subBP;
+
+    expect(onObjectLater).not.toHaveBeenCalled(); // no leaked straggler from A's rejected attempt
+  });
+});
+
 // ─── Pre-send request ownership (onRequestId) ────────────────────────
 //
 // A response can legally arrive before the caller's `await subscribe()`

--- a/packages/webtransport/src/adapter.test.ts
+++ b/packages/webtransport/src/adapter.test.ts
@@ -2623,6 +2623,55 @@ describe('MoqtConnection draft-14', () => {
     expect(adapter.session.state).not.toBe(SessionState.CLOSED);
   });
 
+  // ─── §10.4: control and data streams are not ordered relative to each other.
+  // A publisher may deliver a subscription's objects before the subscriber has
+  // processed its own SUBSCRIBE_OK and bound the track alias. Without buffering,
+  // routeToTrackSubscription finds no route yet and the object is lost forever —
+  // fatal for tracks whose entire content is one object at group 0 (catalogs,
+  // CMAF init segments). ──────────────────────────────────────────────────────
+  it('draft-16: an object arriving before its SUBSCRIBE_OK binds the alias is buffered and delivered once bound', async () => {
+    const mock = createMockTransport();
+    const adapter = await connectAdapter(mock);
+    const enc = (s: string) => new TextEncoder().encode(s);
+    const onObject = vi.fn();
+
+    const subP = adapter.subscribeTrack([enc('live')], enc('vid'), { onObject });
+    await deepFlush();
+
+    const codec = createControlCodec(16);
+    let subReqId = -1n;
+    for (let i = mock.controlWritten.length - 1; i >= 0; i--) {
+      const { message } = codec.decode(mock.controlWritten[i]!, 0);
+      if (message.type === 'SUBSCRIBE') { subReqId = (message as { requestId: bigint }).requestId; break; }
+    }
+    expect(subReqId).not.toBe(-1n);
+
+    const alias = 42n;
+    const header = makeSubgroupHeader({ trackAlias: varint(alias) });
+    const obj = makeSubgroupObject({ objectId: varint(0), payload: new Uint8Array([0xAB]) });
+
+    // The object arrives on the data plane before SUBSCRIBE_OK is processed.
+    const stream = mock.addIncomingStream();
+    stream.push(concat(
+      encodeSubgroupHeader(header),
+      encodeSubgroupObject(obj, header.hasExtensions, varint(0), true),
+    ));
+    await deepFlush();
+
+    expect(onObject).not.toHaveBeenCalled(); // buffered, not yet routable
+
+    mock.pushControlBytes(encodeControlMessage({
+      type: 'SUBSCRIBE_OK', requestId: subReqId, trackAlias: varint(alias),
+      parameters: new Map(), trackExtensions: [],
+    } as ControlMessage));
+    await deepFlush();
+
+    const sub = await subP;
+    expect(sub.trackAlias).toBe(alias);
+    expect(onObject).toHaveBeenCalledOnce();
+    expect(onObject.mock.calls[0]![0].payload).toEqual(obj.payload);
+  });
+
   // ─── §5.1: consistent crossed-response contract — a crossed REQUEST_ERROR (like
   // a crossed SUBSCRIBE_OK) is suppressed from the application onMessage but STILL
   // observed raw on the qlog channel. ──────────────────────────────────────────

--- a/packages/webtransport/src/adapter.ts
+++ b/packages/webtransport/src/adapter.ts
@@ -99,6 +99,12 @@ export interface TrackSubscribeOptions {
   readonly deliveryTimeout?: SubscribeOptions['deliveryTimeout'];
   /** Called for each object delivered on this subscription (stream-based only; datagrams excluded). */
   onObject?: (obj: MoqtObject) => void;
+  /**
+   * Called when a subgroup data stream of this subscription ends gracefully
+   * (FIN). This is the only reliable end-of-subgroup signal when the
+   * publisher does not set the subgroup header's END_OF_GROUP flag.
+   */
+  onSubgroupClosed?: (header: SubgroupHeader) => void;
 }
 
 /**
@@ -114,6 +120,8 @@ export interface TrackSubscription {
   readonly trackAlias: bigint;
   /** Called for each object — mutable, read live on each delivery. */
   onObject: ((obj: MoqtObject) => void) | null;
+  /** Called on graceful FIN of a subgroup data stream — mutable, read live. */
+  onSubgroupClosed: ((header: SubgroupHeader) => void) | null;
   /** Unsubscribe and clean up. */
   unsubscribe(): Promise<void>;
 }
@@ -323,6 +331,17 @@ export class MoqtConnection {
   private rawSubscriptions = new Map<bigint, RawSubState>();
   /** Track subscriptions by trackAlias (active, alias resolved). */
   private rawAliasMaps = new Map<bigint, RawSubState>();
+  /**
+   * Objects that arrived on a data stream before the SUBSCRIBE_OK that binds
+   * their track alias (control and data streams are not ordered relative to
+   * each other, so a fast publisher can deliver before the subscriber has
+   * processed its own SUBSCRIBE_OK). Buffered while ANY subscribeTrack() is
+   * still pending, replayed once the matching alias binds.
+   */
+  private pendingAliasObjects = new Map<bigint, MoqtObject[]>();
+  private static readonly MAX_PENDING_OBJECTS_PER_ALIAS = 256;
+  /** Subgroup stream FINs racing SUBSCRIBE_OK, replayed after the buffered objects. */
+  private pendingAliasCloses = new Map<bigint, SubgroupHeader[]>();
 
   /** Inbound PUBLISH (draft-18 §10.10) stream contexts, keyed by Request ID. */
   private inboundRequestContexts = new Map<bigint, InboundRequestStreamContext>();
@@ -1730,6 +1749,8 @@ export class MoqtConnection {
     }
     this.rawSubscriptions.clear();
     this.rawAliasMaps.clear();
+    this.pendingAliasObjects.clear();
+    this.pendingAliasCloses.clear();
   }
 
   /**
@@ -1929,6 +1950,7 @@ export class MoqtConnection {
       requestId: reqIdBigint,
       trackAlias: 0n, // placeholder, updated when SUBSCRIBE_OK arrives
       onObject: options?.onObject ?? null,
+      onSubgroupClosed: options?.onSubgroupClosed ?? null,
       unsubscribe: async () => {
         // Delegate to the single centralized path: it arms terminal alias
         // protection synchronously (from the raw entry's real alias — null-safe,
@@ -1951,6 +1973,10 @@ export class MoqtConnection {
       const raw = this.rawSubscriptions.get(reqIdBigint);
       if (raw) {
         this.rawSubscriptions.delete(reqIdBigint);
+        if (!this.hasPendingRawSubscription()) {
+          this.pendingAliasObjects.clear();
+          this.pendingAliasCloses.clear();
+        }
         raw.reject?.(err instanceof Error ? err : new Error(String(err)));
       }
     }
@@ -1975,7 +2001,46 @@ export class MoqtConnection {
       pub.onObject?.(obj);
       return true;
     }
+    // The publisher may deliver objects before its SUBSCRIBE_OK is processed
+    // (control and data streams are not ordered relative to each other, §10.4);
+    // dropping them would permanently starve the subscription of anything it
+    // published up front (init segments, catalogs). We cannot yet know WHICH
+    // pending subscribeTrack() this alias belongs to, so buffer tentatively
+    // while any is pending and replay once the alias binds (or is cleared once
+    // no subscription is left pending to claim it).
+    if (this.hasPendingRawSubscription()) {
+      const pending = this.pendingAliasObjects.get(alias) ?? [];
+      if (pending.length < MoqtConnection.MAX_PENDING_OBJECTS_PER_ALIAS) {
+        pending.push(obj);
+        this.pendingAliasObjects.set(alias, pending);
+      }
+      return true;
+    }
     return false;
+  }
+
+  private hasPendingRawSubscription(): boolean {
+    for (const raw of this.rawSubscriptions.values()) {
+      if (raw.resolve !== null) return true;
+    }
+    return false;
+  }
+
+  /** Notify the owning subscription that one of its subgroup streams ended gracefully. */
+  private routeSubgroupClosed(header: SubgroupHeader): void {
+    const alias = BigInt(header.trackAlias);
+    const rawSub = this.rawAliasMaps.get(alias);
+    if (rawSub) {
+      rawSub.sub.onSubgroupClosed?.(header);
+      return;
+    }
+    if (this.hasPendingRawSubscription()) {
+      const pending = this.pendingAliasCloses.get(alias) ?? [];
+      if (pending.length < MoqtConnection.MAX_PENDING_OBJECTS_PER_ALIAS) {
+        pending.push(header);
+        this.pendingAliasCloses.set(alias, pending);
+      }
+    }
   }
 
   // ── receiver §10.11 terminal tracker (bounded, Stream-Count-driven) ──
@@ -2196,6 +2261,16 @@ export class MoqtConnection {
         raw.trackAlias = alias;
         (raw.sub as { trackAlias: bigint }).trackAlias = alias;
         this.rawAliasMaps.set(alias, raw);
+        const buffered = this.pendingAliasObjects.get(alias);
+        if (buffered) {
+          this.pendingAliasObjects.delete(alias);
+          for (const obj of buffered) raw.sub.onObject?.(obj);
+        }
+        const bufferedCloses = this.pendingAliasCloses.get(alias);
+        if (bufferedCloses) {
+          this.pendingAliasCloses.delete(alias);
+          for (const closedHeader of bufferedCloses) raw.sub.onSubgroupClosed?.(closedHeader);
+        }
         // §8/§10.11: record the EFFECTIVE delivery timeout for this alias so a later
         // teardown's guard outlives the window in which the publisher may still
         // deliver old-alias streams — combining the publisher's Track Properties
@@ -2225,6 +2300,10 @@ export class MoqtConnection {
         raw.resolve = null;
         raw.reject = null;
         this.rawSubscriptions.delete(reqId);
+        if (!this.hasPendingRawSubscription()) {
+          this.pendingAliasObjects.clear();
+          this.pendingAliasCloses.clear();
+        }
         return true;
       }
     }
@@ -5630,6 +5709,7 @@ export class MoqtConnection {
             this.onObject?.(streamId, eogGap);
           }
         }
+        this.routeSubgroupClosed(header);
         return;
       }
       buf = this.appendBuffer(buf, value);

--- a/packages/webtransport/src/adapter.ts
+++ b/packages/webtransport/src/adapter.ts
@@ -336,12 +336,24 @@ export class MoqtConnection {
    * their track alias (control and data streams are not ordered relative to
    * each other, so a fast publisher can deliver before the subscriber has
    * processed its own SUBSCRIBE_OK). Buffered while ANY subscribeTrack() is
-   * still pending, replayed once the matching alias binds.
+   * still pending, replayed once the matching alias binds — see
+   * {@link bufferPendingAlias} for the ownership/limit/staleness rules and
+   * {@link clearPendingAlias} for the single centralized cleanup path.
    */
   private pendingAliasObjects = new Map<bigint, MoqtObject[]>();
-  private static readonly MAX_PENDING_OBJECTS_PER_ALIAS = 256;
   /** Subgroup stream FINs racing SUBSCRIBE_OK, replayed after the buffered objects. */
   private pendingAliasCloses = new Map<bigint, SubgroupHeader[]>();
+  /** Running payload-byte total per buffered alias (objects only; closes carry none). */
+  private pendingAliasBytes = new Map<bigint, number>();
+  /** Per-alias TTL: clears the whole bucket if no SUBSCRIBE_OK claims it in time (mirrors {@link expireParkedJoin}). */
+  private pendingAliasTimers = new Map<bigint, ReturnType<typeof setTimeout>>();
+  /** Running total across every buffered alias — the global counterpart to the per-alias cap below. */
+  private pendingAliasTotalBytes = 0;
+  private static readonly MAX_PENDING_OBJECTS_PER_ALIAS = 256;
+  /** Caps how many distinct not-yet-bound aliases can be buffering at once. */
+  private static readonly MAX_PENDING_ALIASES = 64;
+  /** Caps total buffered payload bytes across all pending aliases (peer-controlled data — must fail closed, not grow unbounded). */
+  private static readonly MAX_PENDING_TOTAL_BYTES = 8 * 1024 * 1024;
 
   /** Inbound PUBLISH (draft-18 §10.10) stream contexts, keyed by Request ID. */
   private inboundRequestContexts = new Map<bigint, InboundRequestStreamContext>();
@@ -1749,8 +1761,7 @@ export class MoqtConnection {
     }
     this.rawSubscriptions.clear();
     this.rawAliasMaps.clear();
-    this.pendingAliasObjects.clear();
-    this.pendingAliasCloses.clear();
+    this.clearAllPendingAliases();
   }
 
   /**
@@ -1973,10 +1984,7 @@ export class MoqtConnection {
       const raw = this.rawSubscriptions.get(reqIdBigint);
       if (raw) {
         this.rawSubscriptions.delete(reqIdBigint);
-        if (!this.hasPendingRawSubscription()) {
-          this.pendingAliasObjects.clear();
-          this.pendingAliasCloses.clear();
-        }
+        if (!this.hasPendingRawSubscription()) this.clearAllPendingAliases();
         raw.reject?.(err instanceof Error ? err : new Error(String(err)));
       }
     }
@@ -2006,16 +2014,10 @@ export class MoqtConnection {
     // dropping them would permanently starve the subscription of anything it
     // published up front (init segments, catalogs). We cannot yet know WHICH
     // pending subscribeTrack() this alias belongs to, so buffer tentatively
-    // while any is pending and replay once the alias binds (or is cleared once
-    // no subscription is left pending to claim it).
-    if (this.hasPendingRawSubscription()) {
-      const pending = this.pendingAliasObjects.get(alias) ?? [];
-      if (pending.length < MoqtConnection.MAX_PENDING_OBJECTS_PER_ALIAS) {
-        pending.push(obj);
-        this.pendingAliasObjects.set(alias, pending);
-      }
-      return true;
-    }
+    // while any is pending and replay once the alias binds — see
+    // {@link bufferPendingAlias} for why this refuses aliases already claimed
+    // by a torn-down subscription (§11.1) and fails closed on any limit.
+    if (this.bufferPendingAlias(alias, obj, undefined)) return true;
     return false;
   }
 
@@ -2034,13 +2036,92 @@ export class MoqtConnection {
       rawSub.sub.onSubgroupClosed?.(header);
       return;
     }
-    if (this.hasPendingRawSubscription()) {
-      const pending = this.pendingAliasCloses.get(alias) ?? [];
-      if (pending.length < MoqtConnection.MAX_PENDING_OBJECTS_PER_ALIAS) {
-        pending.push(header);
-        this.pendingAliasCloses.set(alias, pending);
-      }
+    this.bufferPendingAlias(alias, undefined, header);
+  }
+
+  /**
+   * Tentatively buffer one object or graceful subgroup-close FIN for `alias`
+   * while a SUBSCRIBE_OK that could bind it is still outstanding. Refuses
+   * (returns false — caller falls through to the generic unrouted-object
+   * path, never silently drops while pretending to have handled it) when:
+   *  - no subscribeTrack() is currently pending at all (nothing could ever
+   *    claim this alias, buffering it would just leak);
+   *  - a terminal tombstone (`terminatedAliases`) is currently live for this
+   *    alias — §11.1 explicitly permits late objects after a subscription
+   *    tears down, so this is a known straggler from THAT subscription, not
+   *    fresh data for whichever one eventually reuses the alias next. The
+   *    tombstone is only ever armed for an alias that was previously bound
+   *    (see every armTerminatedAlias call site), so this can never
+   *    false-positive on a genuinely new, never-before-seen alias;
+   *  - any global or per-alias limit (distinct aliases, total bytes,
+   *    per-alias object count) would be exceeded — fails closed rather than
+   *    growing unbounded on peer-controlled data.
+   * Starts (or refreshes) a per-alias TTL that clears the whole bucket via
+   * {@link clearPendingAlias} if no SUBSCRIBE_OK claims it in time, mirroring
+   * {@link expireParkedJoin}'s per-entry TTL for the analogous Joining-Fetch
+   * parking structure.
+   */
+  private bufferPendingAlias(alias: bigint, obj: MoqtObject | undefined, closeHeader: SubgroupHeader | undefined): boolean {
+    if (!this.hasPendingRawSubscription()) return false;
+    if (this.terminatedAliases.has(alias)) return false;
+
+    const isNewAlias = !this.pendingAliasTimers.has(alias);
+    const objectBytes = obj !== undefined && obj.kind === 'data' ? obj.payload.byteLength : 0;
+    const currentAliasBytes = this.pendingAliasBytes.get(alias) ?? 0;
+    const currentAliasObjectCount = this.pendingAliasObjects.get(alias)?.length ?? 0;
+
+    if (isNewAlias && this.pendingAliasTimers.size >= MoqtConnection.MAX_PENDING_ALIASES) return false;
+    if (this.pendingAliasTotalBytes + objectBytes > MoqtConnection.MAX_PENDING_TOTAL_BYTES) return false;
+    if (obj !== undefined && currentAliasObjectCount >= MoqtConnection.MAX_PENDING_OBJECTS_PER_ALIAS) return false;
+
+    if (isNewAlias) {
+      this.pendingAliasTimers.set(alias, setTimeout(() => this.clearPendingAlias(alias), this.joiningFetchTimeoutMs));
     }
+    if (obj !== undefined) {
+      const pending = this.pendingAliasObjects.get(alias) ?? [];
+      pending.push(obj);
+      this.pendingAliasObjects.set(alias, pending);
+      this.pendingAliasBytes.set(alias, currentAliasBytes + objectBytes);
+      this.pendingAliasTotalBytes += objectBytes;
+    }
+    if (closeHeader !== undefined) {
+      const pending = this.pendingAliasCloses.get(alias) ?? [];
+      pending.push(closeHeader);
+      this.pendingAliasCloses.set(alias, pending);
+    }
+    return true;
+  }
+
+  /**
+   * Single centralized cleanup for one buffered alias's pending objects/closes,
+   * TTL timer, and byte accounting — called from every settlement and
+   * cancellation path (SUBSCRIBE_OK bind, REQUEST_ERROR, subscribeTrack() send
+   * failure, session teardown, and this bucket's own TTL expiry) instead of
+   * each path clearing state ad hoc. Returns what was buffered (for the bind
+   * path to replay) or undefined if nothing was buffered for this alias.
+   */
+  private clearPendingAlias(alias: bigint): { objects: MoqtObject[]; closes: SubgroupHeader[] } | undefined {
+    const timer = this.pendingAliasTimers.get(alias);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.pendingAliasTimers.delete(alias);
+    }
+    const objects = this.pendingAliasObjects.get(alias);
+    const closes = this.pendingAliasCloses.get(alias);
+    this.pendingAliasObjects.delete(alias);
+    this.pendingAliasCloses.delete(alias);
+    const bytes = this.pendingAliasBytes.get(alias);
+    if (bytes !== undefined) {
+      this.pendingAliasTotalBytes -= bytes;
+      this.pendingAliasBytes.delete(alias);
+    }
+    if (objects === undefined && closes === undefined) return undefined;
+    return { objects: objects ?? [], closes: closes ?? [] };
+  }
+
+  /** Clears every currently-buffered pending alias (session teardown, or the last pending subscribeTrack() settling). */
+  private clearAllPendingAliases(): void {
+    for (const alias of [...this.pendingAliasTimers.keys()]) this.clearPendingAlias(alias);
   }
 
   // ── receiver §10.11 terminal tracker (bounded, Stream-Count-driven) ──
@@ -2261,16 +2342,16 @@ export class MoqtConnection {
         raw.trackAlias = alias;
         (raw.sub as { trackAlias: bigint }).trackAlias = alias;
         this.rawAliasMaps.set(alias, raw);
-        const buffered = this.pendingAliasObjects.get(alias);
-        if (buffered) {
-          this.pendingAliasObjects.delete(alias);
-          for (const obj of buffered) raw.sub.onObject?.(obj);
-        }
-        const bufferedCloses = this.pendingAliasCloses.get(alias);
-        if (bufferedCloses) {
-          this.pendingAliasCloses.delete(alias);
-          for (const closedHeader of bufferedCloses) raw.sub.onSubgroupClosed?.(closedHeader);
-        }
+        // Take-and-clear the buffer NOW (synchronously, alongside binding) so nothing
+        // buffered for this alias can be double-claimed or leak past this settlement -
+        // but defer actually INVOKING the callbacks until after raw.resolve() below.
+        // onObject/onSubgroupClosed are documented "mutable, read live on each delivery":
+        // resolve() only settles the promise, it does not run the caller's own
+        // `await subscribeTrack()` continuation synchronously (that's a later microtask) -
+        // replaying inline here, before that continuation has had a chance to swap in
+        // its real handler, would deliver buffered data into whatever onObject was at
+        // call time, not the "live" one the contract promises.
+        const cleared = this.clearPendingAlias(alias);
         // §8/§10.11: record the EFFECTIVE delivery timeout for this alias so a later
         // teardown's guard outlives the window in which the publisher may still
         // deliver old-alias streams — combining the publisher's Track Properties
@@ -2288,6 +2369,20 @@ export class MoqtConnection {
         raw.resolve?.(raw.sub);
         raw.resolve = null;
         raw.reject = null;
+        if (cleared) {
+          // A plain queueMicrotask is NOT enough of a delay here: subscribeTrack()
+          // is itself an async function, so the promise it returns to the caller
+          // settles ONE MORE microtask tick after raw.resolve() above (the
+          // engine's own thenable-unwrap of `return result`) - a microtask
+          // scheduled right here would still run before that caller ever
+          // observes the resolved subscription. A macrotask reliably runs after
+          // every currently-queued microtask, however many hops that unwrap
+          // takes, so the caller has always had its chance to swap onObject.
+          setTimeout(() => {
+            for (const obj of cleared.objects) raw.sub.onObject?.(obj);
+            for (const closedHeader of cleared.closes) raw.sub.onSubgroupClosed?.(closedHeader);
+          }, 0);
+        }
         return true; // suppress onMessage
       }
     }
@@ -2300,10 +2395,7 @@ export class MoqtConnection {
         raw.resolve = null;
         raw.reject = null;
         this.rawSubscriptions.delete(reqId);
-        if (!this.hasPendingRawSubscription()) {
-          this.pendingAliasObjects.clear();
-          this.pendingAliasCloses.clear();
-        }
+        if (!this.hasPendingRawSubscription()) this.clearAllPendingAliases();
         return true;
       }
     }


### PR DESCRIPTION
Control and data streams aren't ordered relative to each other (draft-ietf-moq-transport-16 §10.4), so a publisher can deliver a subscription's objects before SUBSCRIBE_OK binds the Track Alias. `routeToTrackSubscription` dropped these silently - for tracks that are a single object at group 0 (catalogs, init segments), this loses the track permanently and the subscription hangs.

Buffers objects (and graceful subgroup FINs) per-alias while a `subscribeTrack()` call is pending, then replays them once SUBSCRIBE_OK binds the alias - modeled on the existing `pendingJoinFetches` parking structure and `terminatedAliases` tombstone:

- Refuses to buffer into a tombstoned alias, so a torn-down subscription's late stragglers can never leak into a different subscription that later reuses the same alias.
- Fails closed (falls through to the generic unrouted-object path) on any of three limits: a per-alias object cap, a global distinct-alias cap, or a global buffered-byte cap - previously only the per-alias cap existed, and hitting it silently discarded the overflow object while still reporting it as claimed.
- A per-alias TTL (reusing `joiningFetchTimeoutMs`) clears a bucket nobody claims in time, mirroring `expireParkedJoin`.
- Replay is deferred via `setTimeout` until after `raw.resolve()`'s caller has run its own continuation and swapped in the "live" `onObject`/`onSubgroupClosed`, honoring the documented mutable-callback contract (a plain `queueMicrotask` isn't late enough - `subscribeTrack()`'s own async wrapping adds an extra microtask hop).
- `clearPendingAlias()`/`clearAllPendingAliases()` centralize cleanup, called from every settlement/cancellation path (bind, REQUEST_ERROR, send failure, teardown, TTL expiry) instead of duplicated ad hoc sweeps.

Also adds an `onSubgroupClosed` callback to `TrackSubscribeOptions`, needed to buffer a graceful FIN the same way as objects when a publisher doesn't set the subgroup header's END_OF_GROUP flag.

**Testing:** one regression test per case above (tombstone refusal, deferred-replay ordering, per-alias/global-alias/global-byte fail-closed paths, TTL expiry, centralized cleanup not leaking across alias reuse), plus the original repro in `adapter.test.ts`; full `packages/webtransport` suite passes; `tsc --noEmit` clean; verified live against a real draft-14 relay via a downstream integration.

Originally patched locally against v0.5.0; re-derived here against current `adapter.ts`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq-playa/1)
<!-- Reviewable:end -->
