### PR TITLE
npm: added github action for OIDC publishing on tag.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,137 @@
+# Publish every packages/* tarball to npm when a vMAJOR.MINOR.PATCH tag is pushed.
+#
+# Auth is npm Trusted Publisher (OIDC) — no NPM_TOKEN. Each package on
+# npmjs.com must authorize this file for this repo:
+#   Organization or user : the GitHub org/user that owns the repo
+#   Repository            : the repo name (not owner/name)
+#   Workflow filename     : publish.yml
+#   Environment           : leave empty unless you add `environment:` below
+#   Allowed actions       : npm publish
+#
+# Do not set setup-node `registry-url` and do not set NODE_AUTH_TOKEN /
+# NPM_TOKEN. An empty //registry.npmjs.org/:_authToken shadows the OIDC
+# exchange and npm reports ENEEDAUTH / E404.
+name: publish
+
+on:
+  push:
+    tags:
+      # Glob (not regex). The job still requires exact vMAJOR.MINOR.PATCH.
+      - 'v*.*.*'
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Require npm CLI that supports trusted publishing
+        run: |
+          set -euo pipefail
+          ver="$(npm --version)"
+          echo "npm ${ver}"
+          node -e '
+            const [maj, min, patch] = process.argv[1].split(".").map(Number);
+            const ok = maj > 11 || (maj === 11 && (min > 5 || (min === 5 && patch >= 1)));
+            if (!ok) {
+              console.error("Trusted publishing needs npm >= 11.5.1");
+              process.exit(1);
+            }
+          ' "$ver"
+
+      - name: Verify tag matches package versions
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag must be vMAJOR.MINOR.PATCH (got ${tag})"
+            exit 1
+          fi
+          expected="${tag#v}"
+          node -e '
+            const { readFileSync, readdirSync, existsSync } = require("fs");
+            const { join } = require("path");
+            const expected = process.argv[1];
+            const root = JSON.parse(readFileSync("package.json", "utf8"));
+            if (root.version !== expected) {
+              console.error(`Root package.json version ${root.version} !== tag ${expected}`);
+              process.exit(1);
+            }
+            let n = 0;
+            for (const dir of readdirSync("packages")) {
+              const pf = join("packages", dir, "package.json");
+              if (!existsSync(pf)) continue;
+              const pkg = JSON.parse(readFileSync(pf, "utf8"));
+              if (pkg.private) continue;
+              if (pkg.version !== expected) {
+                console.error(`${pkg.name}: ${pkg.version} !== tag ${expected}`);
+                process.exit(1);
+              }
+              console.log(`  ${pkg.name}@${pkg.version}`);
+              n++;
+            }
+            if (n === 0) {
+              console.error("No publishable packages under packages/");
+              process.exit(1);
+            }
+            console.log(`Tag v${expected} matches ${n} package(s)`);
+          ' "$expected"
+
+      - name: Install (frozen lockfile)
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm -r build
+
+      - name: Test
+        run: pnpm test
+
+      - name: Package README check
+        run: node scripts/generate-package-readmes.mjs --check
+
+      - name: Package export smoke (built bundles)
+        run: pnpm smoke:exports
+
+      - name: Pack publishable packages
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          pnpm --filter "./packages/*" pack --pack-destination "${PWD}/release"
+          ls -lh release/*.tgz
+
+      - name: Publish to npm
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          tarballs=(release/*.tgz)
+          if [ ${#tarballs[@]} -eq 0 ]; then
+            echo "No tarballs in release/"
+            exit 1
+          fi
+          for tgz in "${tarballs[@]}"; do
+            meta="$(tar -xOzf "$tgz" package/package.json)"
+            name="$(printf '%s' "$meta" | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).name")"
+            version="$(printf '%s' "$meta" | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")"
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo "Already on npm: ${name}@${version} — skipping"
+              continue
+            fi
+            echo "Publishing ${name}@${version} from ${tgz}"
+            npm publish "$tgz" --access public
+          done

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,11 +1,20 @@
 #!/usr/bin/env node
 /**
- * Release workflow — build, verify, tag, and optionally publish.
+ * Release workflow — build, verify, pack, and (with --publish) tag.
+ *
+ * npm publish lives in .github/workflows/publish.yml (Trusted Publisher).
+ * This script never uploads; pushing the vMAJOR.MINOR.PATCH tag does.
  *
  * Usage:
  *   node scripts/release.mjs              # verify current version, dry-run
  *   node scripts/release.mjs 0.6.0        # bump to 0.6.0, verify, pack
- *   node scripts/release.mjs --publish    # verify + tag + publish to npm
+ *   node scripts/release.mjs --publish    # verify + tag v{version}
+ *
+ * Typical cut:
+ *   1. node scripts/release.mjs 0.6.0
+ *   2. commit the version bump (tree must be clean before tagging)
+ *   3. node scripts/release.mjs --publish
+ *   4. git push origin HEAD && git push origin v0.6.0
  *
  * Steps:
  *   1. Sync version across all packages (from root or CLI arg)
@@ -14,12 +23,11 @@
  *   4. pnpm test
  *   5. package README check + smoke-exports (boundary verification)
  *   6. Pack the PUBLISHABLE packages only (packages/*) into ./release
- *   7. If --publish: git tag v{version} + pnpm publish --access public
+ *   7. If --publish: git tag v{version} (do not npm publish)
  *
- * Publishing requires a clean working tree (asserted up front), so the
- * tarballs in ./release/ — which cover exactly the packages that publish —
- * are the exact artifacts sent to npm. The tag is created only on publish,
- * so a dry run never leaves a tag with no corresponding release.
+ * --publish requires a clean working tree so the tag points at the commit
+ * that the GitHub Action will check out and publish. The tag is created
+ * only on --publish, so a dry run never leaves a tag with no release.
  */
 
 import { execSync } from 'child_process';
@@ -41,13 +49,13 @@ function runCapture(cmd) {
   return execSync(cmd, { cwd: ROOT, encoding: 'utf-8' }).trim();
 }
 
-// ── Guard: never publish from a dirty tree ───────────────────────────
-// Publishing packs from the working tree; a dirty tree would ship artifacts
-// the git tag does not represent. Require a clean, committed state up front.
+// ── Guard: never tag from a dirty tree ───────────────────────────────
+// The GitHub Action publishes whatever the tag points at. A dirty tree
+// would tag a commit that does not include the files about to ship.
 if (shouldPublish) {
   const dirty = runCapture('git status --porcelain');
   if (dirty) {
-    console.error('\n✗ Refusing to publish from a dirty working tree — commit or stash first:\n');
+    console.error('\n✗ Refusing to tag from a dirty working tree — commit or stash first:\n');
     console.error(dirty + '\n');
     process.exit(1);
   }
@@ -108,9 +116,9 @@ const tarballs = runCapture(`ls -lh "${releaseDir}"/*.tgz`);
 console.log('\nTarballs:');
 console.log(tarballs);
 
-// ── Step 7: Tag + Publish (opt-in) ───────────────────────────────────
-// Tag only when actually publishing (the clean-tree guard above ran), so a
-// dry run never leaves a tag with no corresponding release.
+// ── Step 7: Tag (opt-in) ─────────────────────────────────────────────
+// Tag only on --publish (the clean-tree guard above ran), so a dry run
+// never leaves a tag with no corresponding GitHub Action run.
 
 const tag = `v${version}`;
 
@@ -121,12 +129,11 @@ if (shouldPublish) {
     console.log(`\n🏷  Tagging ${tag}`);
     execSync(`git tag -a ${tag} -m "Release ${tag}"`, { cwd: ROOT });
   }
-  console.log('\n🚀 Publishing to npm...');
-  run('pnpm --filter "./packages/*" publish --access public --no-git-checks');
-  console.log(`\n✅ Published v${version} to npm`);
-  console.log(`   Push the tag: git push origin ${tag}`);
+  console.log(`\n✅ Tagged ${tag}`);
+  console.log('   npm publish runs in CI when this tag reaches origin:');
+  console.log(`   git push origin HEAD && git push origin ${tag}`);
 } else {
   console.log(`\n✅ Release v${version} verified`);
-  console.log('   Tarballs in ./release/ are exactly what would publish.');
-  console.log('   To publish (from a clean tree): node scripts/release.mjs --publish');
+  console.log('   Tarballs in ./release/ are exactly what CI would publish.');
+  console.log('   To tag (from a clean tree): node scripts/release.mjs --publish');
 }


### PR DESCRIPTION
* Adding github action to trigger on tag (e.g., `v0.6.0`)
* Modified `release.mjs` to not npm publish on `--publish`
* `release.mjs --publish` will only push the tag to npm, which will trigger the publish action once OIDC is setup
---

Example of kicking off version bump, tag and npm publish:

```
node scripts/release.mjs 0.6.0          # bump + verify (dirties the tree)
git add -u && git commit -m "Release 0.6.0"
node scripts/release.mjs --publish       # tag v0.6.0
git push origin HEAD && git push origin v0.6.0
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq-playa/4)
<!-- Reviewable:end -->
