### PR TITLE
feat(webtransport): report Forward State changes on outbound PUBLISHes

### DIFF
--- a/packages/webtransport/src/adapter-d18-data.test.ts
+++ b/packages/webtransport/src/adapter-d18-data.test.ts
@@ -17,6 +17,7 @@ import {
   writeVi64,
   vi64EncodingLength,
   varint,
+  MessageParam,
   StreamType18,
   PADDING_DATAGRAM_TYPE,
   DatagramFlags18,
@@ -2012,6 +2013,30 @@ describe('MoqtConnection(18) outbound PUBLISH (§10.10)', () => {
     const { message } = codec18.decode(transport.bidi[0]!.writtenBytes(), 0) as { message: { type: string; trackProperties?: Map<bigint, unknown> } };
     expect(message.type).toBe('PUBLISH');
     expect(message.trackProperties).toEqual(trackProperties);
+  });
+
+  it('REQUEST_OK Forward State 0 then a peer REQUEST_UPDATE FORWARD=1 report pause and resume (§5.1 / §9.5)', async () => {
+    const { conn, transport } = await connected();
+    const changes: [bigint, boolean][] = [];
+    conn.onPublishForwardStateChange = (id, fwd) => changes.push([id, fwd]);
+    // d18 §5.1: resuming 0→1 makes the REQUEST_OK carry the current Largest Location.
+    conn.setLargestLocationProvider(() => ({ group: 0n, object: 0n }));
+    const forwardParams = (forward: bigint) => new Map([[MessageParam.FORWARD, [varint(forward)]]]);
+
+    const requestId = await conn.publish(ns('a'), nm('vid'), 42n);
+    expect(conn.getPublishForwardState(requestId)).toBe(true);
+    transport.bidi[0]!.push(codec18.encode({ type: 'REQUEST_OK', requestId: 0n, parameters: forwardParams(0n) } as RequestOk));
+    await flush();
+    expect(changes).toEqual([[requestId, false]]);
+    expect(conn.getPublishForwardState(requestId)).toBe(false);
+
+    const writtenBefore = transport.bidi[0]!.writtenBytes().length;
+    transport.bidi[0]!.push(codec18.encode({ type: 'REQUEST_UPDATE', requestId: 3n, parameters: forwardParams(1n) } as never));
+    await flush();
+    expect(changes).toEqual([[requestId, false], [requestId, true]]);
+    expect(conn.getPublishForwardState(requestId)).toBe(true);
+    // The resume was acknowledged on the PUBLISH stream (REQUEST_OK, 0x07) before the callback fired.
+    expect(transport.bidi[0]!.writtenBytes()[writtenBefore]).toBe(0x07);
   });
 
   it('REQUEST_OK on the PUBLISH stream is stamped to the publish requestId and keeps the stream open', async () => {

--- a/packages/webtransport/src/adapter.test.ts
+++ b/packages/webtransport/src/adapter.test.ts
@@ -23,6 +23,7 @@ import {
   SessionError,
   EndpointRole,
   varint,
+  MessageParam,
   encodeSubgroupHeader,
   encodeSubgroupObject,
   decodeSubgroupHeader,
@@ -6126,5 +6127,75 @@ describe('terminal drain — review findings (alias reuse, completion race, shut
     await tflush2();
     await vi.advanceTimersByTimeAsync(10_001);
     await tflush2();                                     // would surface unhandled rejection if not contained
+  });
+});
+
+// ─── Outbound PUBLISH Forward State (§5.1 / §8.5) ──────────────────────────
+
+describe('outbound PUBLISH forward state (draft-16)', () => {
+  const enc = (s: string) => new TextEncoder().encode(s);
+  const forwardParams = (forward: bigint) => new Map([[MessageParam.FORWARD, [varint(forward)]]]);
+
+  async function publishedWithChanges(): Promise<{
+    adapter: MoqtConnection; mock: MockTransport; requestId: bigint; changes: [bigint, boolean][];
+  }> {
+    const mock = createMockTransport();
+    // Advertise a request-ID budget so the relay's own REQUEST_UPDATE (id 1, 3) is in range.
+    const adapter = new MoqtConnection();
+    const connectPromise = adapter.connect(mock.transport, { maxRequestId: varint(100) });
+    await flush();
+    mock.pushControlBytes(encodeServerSetup());
+    await connectPromise;
+    const changes: [bigint, boolean][] = [];
+    adapter.onPublishForwardStateChange = (id, fwd) => changes.push([id, fwd]);
+    adapter.onClose = (code, reason) => { throw new Error(`session closed: ${code} ${reason}`); };
+    const requestId = await adapter.publish([enc('media'), enc('avn')], enc('catalog'), 0n);
+    await flush();
+    return { adapter, mock, requestId, changes };
+  }
+
+  it('a PUBLISH_OK with Forward State 0 reports the pause and is readable', async () => {
+    const { adapter, mock, requestId, changes } = await publishedWithChanges();
+    expect(adapter.getPublishForwardState(requestId)).toBe(true); // §5.1 initial state from PUBLISH
+
+    mock.pushControlBytes(encodeControlMessage({
+      type: 'PUBLISH_OK', requestId: varint(requestId), parameters: forwardParams(0n),
+    } as ControlMessage));
+    await deepFlush();
+
+    expect(changes).toEqual([[requestId, false]]);
+    expect(adapter.getPublishForwardState(requestId)).toBe(false);
+  });
+
+  it('a later peer REQUEST_UPDATE with FORWARD=1 reports the resume (§8.5: relay had no subscriber at PUBLISH time)', async () => {
+    const { adapter, mock, requestId, changes } = await publishedWithChanges();
+    mock.pushControlBytes(encodeControlMessage({
+      type: 'PUBLISH_OK', requestId: varint(requestId), parameters: forwardParams(0n),
+    } as ControlMessage));
+    await deepFlush();
+
+    // The relay's own update: server-initiated request IDs are odd.
+    mock.pushControlBytes(encodeControlMessage({
+      type: 'REQUEST_UPDATE', requestId: varint(1n), existingRequestId: varint(requestId), parameters: forwardParams(1n),
+    } as ControlMessage));
+    await deepFlush();
+
+    expect(changes).toEqual([[requestId, false], [requestId, true]]);
+    expect(adapter.getPublishForwardState(requestId)).toBe(true);
+  });
+
+  it('a REQUEST_UPDATE that does not change Forward State, or repeats it, is silent', async () => {
+    const { adapter, mock, requestId, changes } = await publishedWithChanges();
+    mock.pushControlBytes(encodeControlMessage({
+      type: 'REQUEST_UPDATE', requestId: varint(1n), existingRequestId: varint(requestId), parameters: new Map(),
+    } as ControlMessage));
+    mock.pushControlBytes(encodeControlMessage({
+      type: 'REQUEST_UPDATE', requestId: varint(3n), existingRequestId: varint(requestId), parameters: forwardParams(1n),
+    } as ControlMessage));
+    await deepFlush();
+
+    expect(changes).toEqual([]);
+    expect(adapter.getPublishForwardState(requestId)).toBe(true);
+    expect(adapter.getPublishForwardState(999n)).toBeUndefined();
   });
 });

--- a/packages/webtransport/src/adapter.ts
+++ b/packages/webtransport/src/adapter.ts
@@ -477,6 +477,20 @@ export class MoqtConnection {
    */
   onMessage?: (msg: ControlMessage) => void;
 
+  /**
+   * Called when the Forward State of one of OUR outbound PUBLISHes changes: the
+   * subscriber's acceptance (PUBLISH_OK on draft-14/16, REQUEST_OK on draft-18) or
+   * a later peer REQUEST_UPDATE carried a FORWARD that differs from the current
+   * state. §5.1: "The publisher does not send Objects if the Forward State is 0,
+   * and does send them if the Forward State is 1." A relay MAY accept a PUBLISH
+   * with Forward State 0 until it has a subscriber (§8.5) and then raises it with
+   * REQUEST_UPDATE (§8.5; d18 §9.5), so a publisher that reads Forward only from
+   * the acceptance never starts sending on a relay that had no viewer yet. Fires
+   * after the session applied the change (and, on draft-18, after the REQUEST_OK
+   * was written); `getPublishForwardState` reads the current value at any time.
+   */
+  onPublishForwardStateChange?: (requestId: bigint, forward: boolean) => void;
+
   /** Called when the control stream or connection closes. */
   onClose?: (error?: number, reason?: string) => void;
 
@@ -1682,6 +1696,36 @@ export class MoqtConnection {
   }
 
   /** Route a draft-18 request-stream response through the standard pipeline. */
+  /**
+   * Current Forward State of one of OUR outbound PUBLISHes: `true` when the
+   * subscriber wants Objects, `false` when it set Forward State 0, `undefined`
+   * when `requestId` is not a live outbound PUBLISH.
+   */
+  getPublishForwardState(requestId: bigint): boolean | undefined {
+    const pub = this.session.getOutgoingPublish(requestId);
+    return pub === undefined ? undefined : pub.forwardState === ForwardState.ACTIVE;
+  }
+
+  /**
+   * The outbound PUBLISH whose Forward State `message` may change, or undefined:
+   * a PUBLISH_OK / REQUEST_OK names it by requestId, a REQUEST_UPDATE by
+   * existingRequestId (already stamped on draft-18 by the request stream).
+   */
+  private outboundPublishForwardTarget(message: { type: string; requestId?: bigint; existingRequestId?: bigint }): bigint | undefined {
+    const target = message.type === 'REQUEST_UPDATE'
+      ? message.existingRequestId
+      : (message.type === 'PUBLISH_OK' || message.type === 'REQUEST_OK') ? message.requestId : undefined;
+    if (target === undefined || this.session.getOutgoingPublish(target) === undefined) return undefined;
+    return target;
+  }
+
+  /** Fire onPublishForwardStateChange when the state moved from `before`. */
+  private notifyPublishForwardChange(requestId: bigint | undefined, before: boolean | undefined): void {
+    if (requestId === undefined || before === undefined) return;
+    const after = this.getPublishForwardState(requestId);
+    if (after !== undefined && after !== before) this.onPublishForwardStateChange?.(requestId, after);
+  }
+
   private async deliverRequestResponse(message: DecodedControlMessage, requestId: bigint): Promise<void> {
     // Stamp the stream-derived Request ID (codec leaves it absent on responses).
     const stamped = { ...message, requestId } as ControlMessage;
@@ -1727,7 +1771,10 @@ export class MoqtConnection {
     const suppress = this.handleRawSubControlMessage(stamped)
       || this.session.isCancelledRequest(requestId);
     if (!suppress) this.onMessage?.(stamped);
+    const fwdTarget = this.outboundPublishForwardTarget(stamped as { type: string; requestId?: bigint });
+    const fwdBefore = fwdTarget === undefined ? undefined : this.getPublishForwardState(fwdTarget);
     await this.executeActions(this.session.handleControlMessage(message, { requestId }));
+    this.notifyPublishForwardChange(fwdTarget, fwdBefore);
     // §10.13: a FETCH_OK may complete the fetch (its data stream already FIN'd, in
     // the object-delivery-before-response order) — close the request bidi so the
     // fetcher's topology context does not leak.
@@ -1944,6 +1991,7 @@ export class MoqtConnection {
     const updateId = (message as { requestId: bigint }).requestId;
     const stamped = { ...message, existingRequestId: originalRequestId } as ControlMessage;
     this.onMessage?.(stamped);
+    const fwdBefore = this.getPublishForwardState(originalRequestId);
     const actions = this.session.handleControlMessage(stamped, {
       requestId: updateId,
       existingRequestId: originalRequestId,
@@ -1957,6 +2005,9 @@ export class MoqtConnection {
     const send = actions.find((a) => a.type === 'send_control') as SendControlAction | undefined;
     if (send) await this.uniPair!.writeOnRequest(originalRequestId, send.message);
     await this.executeActions(actions.filter((a) => a.type !== 'send_control'));
+    // The REQUEST_OK is on the wire; now tell the application it may (or must
+    // stop) sending. A rejected update (REQUEST_ERROR) leaves the state as it was.
+    if (send?.message.type !== 'REQUEST_ERROR') this.notifyPublishForwardChange(originalRequestId, fwdBefore);
     // d18 §10.11: a FAILED subscription update terminates the subscription —
     // the adapter-owned transaction sends PUBLISH_DONE(UPDATE_FAILED) on this
     // same publish request stream and seals it.
@@ -4867,9 +4918,14 @@ export class MoqtConnection {
           const subBefore = message.type === 'SUBSCRIBE'
             ? this.session.getIncomingSubscription((message as Subscribe).requestId)
             : undefined;
+          // Forward State of OUR outbound PUBLISH before the subscriber's
+          // PUBLISH_OK / REQUEST_UPDATE is applied, so a change can be reported.
+          const fwdTarget = this.outboundPublishForwardTarget(message as { type: string; requestId?: bigint; existingRequestId?: bigint });
+          const fwdBefore = fwdTarget === undefined ? undefined : this.getPublishForwardState(fwdTarget);
           const actions = this.session.handleControlMessage(message);
           await this.executeActions(actions);
           await doneDiscard;
+          this.notifyPublishForwardChange(fwdTarget, fwdBefore);
           // Fire AFTER session processing so incomingSubscriptions is populated
           // when acceptSubscribe is called (§5.1: admission = a NEW SM identity,
           // and the session did not close on this message).


### PR DESCRIPTION
A relay MAY accept a PUBLISH with Forward State 0 until it has a subscriber (draft-16 §8.5) and then raise it with REQUEST_UPDATE (§8.5; draft-18 §9.5). The session already applied that update to the outbound publish's state machine, but the adapter exposed neither the transition nor the state, so a publisher that read Forward only from the acceptance never started sending when it connected to a relay with no viewer yet (observed with the Red5 Pro SDK against red5-moq-relay, 2026-09-02).

Adds onPublishForwardStateChange(requestId, forward), fired from the three places a subscriber changes our publish's Forward State: PUBLISH_OK on the draft-14/16 control stream, REQUEST_OK on the draft-18 publish stream, and a peer REQUEST_UPDATE on either (after the REQUEST_OK is written on draft-18; not on a rejected update). Adds getPublishForwardState(requestId) to read the current value. Tests cover pause on acceptance, resume on update, and silence on a no-op update for both drafts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq-playa/8)
<!-- Reviewable:end -->
