### PR TITLE
fix(browser): tolerate a late trailing object from the previous CMAF group

### DIFF
--- a/packages/browser/src/cmaf-assembler.test.ts
+++ b/packages/browser/src/cmaf-assembler.test.ts
@@ -757,7 +757,7 @@ describe('CmafAssembler — HEVC CRA-with-RASL strip', () => {
     expect(onDiscontinuity).toHaveBeenCalledWith('audio', 'audio-0');
   });
 
-  it('any backward video bmd triggers discontinuity', () => {
+  it('backward video bmd on a NEW group triggers discontinuity', () => {
     const onSegment = vi.fn();
     const onDiscontinuity = vi.fn();
     const assembler = new CmafAssembler({ onSegment, onDiscontinuity });
@@ -766,8 +766,59 @@ describe('CmafAssembler — HEVC CRA-with-RASL strip', () => {
     assembler.push('video', 'video-0', 0n, combinedSeg(1000));
     assembler.push('video', 'video-0', 1n, combinedSeg(2000));
 
-    // Even small backward jump on video triggers discontinuity
+    // A backward jump on a group newer than any seen is a discontinuity
     assembler.push('video', 'video-0', 2n, combinedSeg(1500));
+
+    expect(onDiscontinuity).toHaveBeenCalledWith('video', 'video-0');
+  });
+
+  it('late trailing video object from the previous group is NOT a discontinuity', () => {
+    const onSegment = vi.fn();
+    const onDiscontinuity = vi.fn();
+    const assembler = new CmafAssembler({ onSegment, onDiscontinuity });
+    const internals = assembler as unknown as { videoEpoch: bigint | null };
+
+    assembler.push('video', 'video-0', 5n, combinedSeg(90000));
+    const epochAfterFirst = internals.videoEpoch;
+    assembler.push('video', 'video-0', 5n, combinedSeg(93000));
+    assembler.push('video', 'video-0', 5n, combinedSeg(96000));
+
+    // Group 6's first object is read before group 5's last one
+    assembler.push('video', 'video-0', 6n, combinedSeg(180000));
+    assembler.push('video', 'video-0', 5n, combinedSeg(177000));
+
+    expect(onDiscontinuity).not.toHaveBeenCalled();
+    expect(onSegment).toHaveBeenCalledTimes(5);
+    expect(internals.videoEpoch).toBe(epochAfterFirst);
+
+    const group6: Uint8Array = onSegment.mock.calls[3]![1];
+    const lateGroup5: Uint8Array = onSegment.mock.calls[4]![1];
+    expect(readBaseMediaDecodeTime(lateGroup5)!).toBeLessThan(readBaseMediaDecodeTime(group6)!);
+  });
+
+  it('video group id back by two with a large bmd jump is still a discontinuity', () => {
+    const onSegment = vi.fn();
+    const onDiscontinuity = vi.fn();
+    const assembler = new CmafAssembler({ onSegment, onDiscontinuity });
+
+    assembler.push('video', 'video-0', 5n, combinedSeg(900000));
+    assembler.push('video', 'video-0', 6n, combinedSeg(990000));
+
+    assembler.push('video', 'video-0', 4n, combinedSeg(1000));
+
+    expect(onDiscontinuity).toHaveBeenCalledWith('video', 'video-0');
+  });
+
+  it('video restart within the first two groups is still a discontinuity', () => {
+    const onSegment = vi.fn();
+    const onDiscontinuity = vi.fn();
+    const assembler = new CmafAssembler({ onSegment, onDiscontinuity });
+
+    assembler.push('video', 'video-0', 0n, combinedSeg(90000));
+    assembler.push('video', 'video-0', 1n, combinedSeg(180000));
+
+    // Publisher restart: group 0 again, one group behind, but bmd back by the whole session
+    assembler.push('video', 'video-0', 0n, combinedSeg(0));
 
     expect(onDiscontinuity).toHaveBeenCalledWith('video', 'video-0');
   });

--- a/packages/browser/src/cmaf-assembler.ts
+++ b/packages/browser/src/cmaf-assembler.ts
@@ -143,6 +143,7 @@ export class CmafAssembler {
   /** Last raw bmd seen per media type — detects backward jumps (discontinuity). */
   private lastVideoBmd: bigint | null = null;
   private lastAudioBmd: bigint | null = null;
+  private lastVideoGroup: bigint | null = null;
 
   /** Track name associated with the current epoch, for scoped timeline clear. */
   private videoTrackName: string | null = null;
@@ -442,6 +443,7 @@ export class CmafAssembler {
     this.audioEpoch = null;
     this.lastVideoBmd = null;
     this.lastAudioBmd = null;
+    this.lastVideoGroup = null;
     this.videoTrackName = null;
     this.audioTrackName = null;
     this.videoTrex = null;
@@ -578,6 +580,7 @@ export class CmafAssembler {
         this.videoEpoch = bmd;
         this.videoTrackName = trackName;
         this.lastVideoBmd = null;
+        this.lastVideoGroup = null;
         this.videoEpochGen = this.sharedEpochGen;
       } else {
         this.audioEpoch = bmd;
@@ -593,21 +596,24 @@ export class CmafAssembler {
         this.videoEpoch = anchored;
         this.videoTrackName = trackName;
         this.lastVideoBmd = null;
+        this.lastVideoGroup = null;
       } else {
         this.audioEpoch = anchored;
         this.audioTrackName = trackName;
         this.lastAudioBmd = null;
       }
     } else if (lastBmd !== null && bmd < lastBmd) {
-      // Same track, bmd went backward.
-      // Audio: backward jumps of at most one second in the track's media
-      // timescale are late subgroup data, not a real discontinuity. Use
-      // the historical 48 kHz window when no init segment was available.
-      // Video: any backward jump is treated as a discontinuity.
+      // Same track, bmd went backward. Adjacent groups arrive on separate streams in
+      // either order, so a jump of at most one second is late subgroup data, not a
+      // discontinuity; video also requires the group to be the current or previous one.
       const jumpBack = lastBmd - bmd;
-      const audioReorderWindow = BigInt(this.audioTimescale ?? 48000);
-      const isSmallAudioReorder = mediaType === 'audio' && jumpBack <= audioReorderWindow;
-      if (!isSmallAudioReorder) {
+      const timescale = mediaType === 'video' ? (this.videoTimescale ?? 90000) : (this.audioTimescale ?? 48000);
+      const reorderWindow = BigInt(timescale);
+      const lastGroup = this.lastVideoGroup;
+      const groupIsRecent = mediaType === 'audio' || groupId === undefined || lastGroup === null
+        || (groupId <= lastGroup && lastGroup - groupId <= 1n);
+      const isLateSubgroupData = groupIsRecent && jumpBack <= reorderWindow;
+      if (!isLateSubgroupData) {
         if (this.debug) console.warn('[CMAF] %s discontinuity on "%s": bmd=%s < lastBmd=%s (jump=%s) — re-anchoring',
           mediaType, trackName, bmd, lastBmd, jumpBack);
         this.onDiscontinuity?.(mediaType, trackName);
@@ -620,6 +626,7 @@ export class CmafAssembler {
         if (mediaType === 'video') {
           this.videoEpoch = anchored;
           this.lastVideoBmd = bmd;
+          this.lastVideoGroup = groupId ?? null;
         } else {
           this.audioEpoch = anchored;
           this.lastAudioBmd = bmd;
@@ -632,6 +639,7 @@ export class CmafAssembler {
     // to look like a forward jump past the reordered one.
     if (mediaType === 'video') {
       if (this.lastVideoBmd === null || bmd > this.lastVideoBmd) this.lastVideoBmd = bmd;
+      if (groupId !== undefined && (this.lastVideoGroup === null || groupId > this.lastVideoGroup)) this.lastVideoGroup = groupId;
     } else {
       if (this.lastAudioBmd === null || bmd > this.lastAudioBmd) this.lastAudioBmd = bmd;
     }


### PR DESCRIPTION
## Problem

Against Wowza Streaming Engine LL-CMAF playout with one-frame video chunks (33 ms), video freezes for tens of seconds every few minutes and then snaps back. The CMAF assembler logs a video discontinuity and re-anchors the video epoch to zero, so the MSE video buffer restarts at 0 while audio continues and the playhead stalls.

A Chrome netlog shows the wire order is correct and nothing is lost: the server writes the last chunk of group N, the FIN of N's subgroup stream, then the header and keyframe of group N+1 in one burst. But the WebTransport adapter's accept loop hands each incoming uni stream to an unawaited reader, and when two streams have data ready in the same millisecond Chrome resolves their reads in no guaranteed order. The assembler therefore sometimes sees N+1's first object before N's last one. MoQ guarantees no ordering across streams, so the client has to tolerate this. Audio already did (a one-second reorder window); video treated any backward tfdt as a restart.

## Rule

In `patchEpoch`, a backward video bmd is late subgroup data rather than a discontinuity when **both** hold:

1. the group id is unknown, or it is the current group or the one immediately before it (a new `lastVideoGroup` high-water mark, cleared wherever `lastVideoBmd` is);
2. the jump is at most one second in the video timescale (`videoTimescale`, 90000 fallback).

Everything else, including a newer group with a backward bmd, a group two or more behind, and a publisher restart whose bmd jumps back further than a second, still re-anchors. Audio behaviour is unchanged.

## Tests (`packages/browser/src/cmaf-assembler.test.ts`)

- `late trailing video object from the previous group is NOT a discontinuity`: groups 5, 5, 5, then 6, then a late group-5 object. No discontinuity, five segments, epoch unchanged, late object's patched tfdt below the group-6 one. Fails on `main`, passes here.
- `video group id back by two with a large bmd jump is still a discontinuity`.
- `video restart within the first two groups is still a discontinuity`: groups 0, 1, then group 0 again at bmd 0. This is why both conditions are required; group 0 is "immediately before" group 1 but the jump is the whole session. Goes red if the window check is dropped.
- The existing `any backward video bmd triggers discontinuity` is renamed to `backward video bmd on a NEW group triggers discontinuity`; its assertion is unchanged and it goes red if the group check is dropped.

## Lab result

Wowza Streaming Engine trial container, `cmafLLChunkDurationTargetVideo` = 33 ms, headless Chrome via Playwright, probe reporting raw wire tfdt per track and tfdt after the assembler. The unfixed baseline happened not to hit the race in its five minutes; the 2026-09-02 investigation saw it three times in 150 s with a video freeze each time.

| measure | unfixed (5ce60c3c) | fixed (this branch) |
| --- | --- | --- |
| run length | 300 s | 600 s |
| wire backward video tfdt steps | 0 (race did not occur in the window) | 5 (one frame of group N after N+1's first chunk each time) |
| appended backward video tfdt steps | 0 | 0 |
| stallCount | 0 | 0 |
| video re-anchor (appended tfdt range restarting near 0) | none | none (0.99 s to 600.74 s, monotonic) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkAhnFTNMnBaCKZqsaC12a

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmoq/moq-playa/9)
<!-- Reviewable:end -->
